### PR TITLE
Changes for windows

### DIFF
--- a/docs/docs/release_notes.md
+++ b/docs/docs/release_notes.md
@@ -1,3 +1,8 @@
+### 3.0.2
+- Added 'utf-8' encoding while opening the file "README.md" in setup.py
+- Fixed panther shell not working issue in windows.
+- Added a condition to raise error if no arguement is passed to panther command in cli.
+
 ### 3.0.1
 - Assume content-type is 'application/json' if it was empty
 - Fix an issue on creating instance of model when query is done

--- a/panther/__init__.py
+++ b/panther/__init__.py
@@ -1,6 +1,6 @@
 from panther.main import Panther  # noqa: F401
 
-__version__ = '3.0.1'
+__version__ = '3.0.2'
 
 
 def version():

--- a/panther/cli/main.py
+++ b/panther/cli/main.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import platform
 
 from rich import print as rprint
 
@@ -11,8 +12,8 @@ from panther.cli.utils import clean_args, cli_error, help_message
 
 
 def shell() -> None:
-    if sys.platform == "win32":
-        cli_error("Currently this feature is not supported for Windows.")
+    if platform.system().lower() == "windows":
+        os.system('python')
     else:
         os.system('bpython')
 
@@ -22,21 +23,24 @@ def version() -> None:
 
 
 def start() -> None:
-    command = sys.argv and sys.argv[1] or None
-    args = clean_args(sys.argv[2:])
+    if len(sys.argv) < 2:
+        cli_error("Please pass some arguments to the command.")
+    else:
+        command = sys.argv and sys.argv[1] or None
+        args = clean_args(sys.argv[2:])
 
-    match command:
-        case '-h' | '--help':
-            rprint(help_message)
-        case 'create':
-            create(sys.argv[2:])
-        case 'run':
-            run(args)
-        case 'shell':
-            shell()
-        case 'monitor':
-            monitor()
-        case 'version':
-            version()
-        case _:
-            cli_error('Invalid Arguments.')
+        match command:
+            case '-h' | '--help':
+                rprint(help_message)
+            case 'create':
+                create(sys.argv[2:])
+            case 'run':
+                run(args)
+            case 'shell':
+                shell()
+            case 'monitor':
+                monitor()
+            case 'version':
+                version()
+            case _:
+                cli_error('Invalid Arguments.')

--- a/panther/cli/main.py
+++ b/panther/cli/main.py
@@ -13,7 +13,8 @@ from panther.cli.utils import clean_args, cli_error, help_message
 def shell() -> None:
     if sys.platform == "win32":
         cli_error("Currently this feature is not supported for Windows.")
-    os.system('bpython')
+    else:
+        os.system('bpython')
 
 
 def version() -> None:

--- a/panther/cli/main.py
+++ b/panther/cli/main.py
@@ -11,6 +11,8 @@ from panther.cli.utils import clean_args, cli_error, help_message
 
 
 def shell() -> None:
+    if sys.platform == "win32":
+        cli_error("Currently this feature is not supported for Windows.")
     os.system('bpython')
 
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def panther_version() -> str:
 
 
 VERSION = panther_version()
-with open('README.md') as file:
+with open('README.md', encoding='utf-8') as file:
     DESCRIPTION = file.read()
 
 EXTRAS_REQUIRE = {


### PR DESCRIPTION
- In setup.py, added encoding as "utf-8" while opening README.md, without which setup was not working for windows.
- Added a temporary message in panther > cli > main.py for shell( ), saying "Currently this feature is not supported for Windows", can be removed when the feature is added.