### PR TITLE
fix background task async loop mismatch with app event loop registration

### DIFF
--- a/panther/background_tasks.py
+++ b/panther/background_tasks.py
@@ -32,6 +32,13 @@ if TYPE_CHECKING:
 __all__ = ('BackgroundTask', 'WeekDay')
 
 logger = logging.getLogger('panther')
+_application_event_loop: asyncio.AbstractEventLoop | None = None
+
+
+def register_application_event_loop(loop: asyncio.AbstractEventLoop | None) -> None:
+    global _application_event_loop
+    _application_event_loop = loop
+
 
 if sys.version_info.minor >= 11:
     from typing import Self
@@ -169,7 +176,12 @@ class BackgroundTask:
             self._remaining_interval -= 1
         try:
             if is_function_async(self._func):
-                asyncio.run(self._func(*self._args, **self._kwargs))
+                coroutine = self._func(*self._args, **self._kwargs)
+                app_loop = _application_event_loop
+                if app_loop and app_loop.is_running() and not app_loop.is_closed():
+                    asyncio.run_coroutine_threadsafe(coroutine, app_loop).result()
+                else:
+                    asyncio.run(coroutine)
             else:
                 self._func(*self._args, **self._kwargs)
         except Exception as e:

--- a/panther/background_tasks.py
+++ b/panther/background_tasks.py
@@ -40,6 +40,10 @@ def register_application_event_loop(loop: asyncio.AbstractEventLoop | None) -> N
     _application_event_loop = loop
 
 
+def get_application_event_loop() -> asyncio.AbstractEventLoop | None:
+    return _application_event_loop
+
+
 if sys.version_info.minor >= 11:
     from typing import Self
 else:

--- a/panther/events.py
+++ b/panther/events.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 
 from panther._utils import is_function_async
+from panther.background_tasks import get_application_event_loop
 from panther.utils import Singleton
 
 logger = logging.getLogger('panther')
@@ -45,7 +46,11 @@ class Event(Singleton):
         for func in cls._shutdowns:
             if is_function_async(func):
                 try:
-                    asyncio.run(func())
+                    app_loop = get_application_event_loop()
+                    if app_loop and app_loop.is_running() and not app_loop.is_closed():
+                        asyncio.run_coroutine_threadsafe(func(), app_loop).result()
+                    else:
+                        asyncio.run(func())
                 except ModuleNotFoundError:
                     # Error: import of asyncio halted; None in sys.modules
                     #   And as I figured it out, it only happens when we are running with

--- a/panther/main.py
+++ b/panther/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import sys
 from collections.abc import Callable
@@ -13,6 +14,9 @@ from panther._utils import (
     ENDPOINT_WEBSOCKET,
     reformat_code,
     traceback_message,
+)
+from panther.background_tasks import (
+    register_application_event_loop,
 )
 from panther.base_websocket import Websocket
 from panther.cli.utils import print_info
@@ -80,6 +84,8 @@ class Panther:
         check_endpoints_inheritance()
 
     async def __call__(self, scope: dict, receive: Callable, send: Callable) -> None:
+        register_application_event_loop(asyncio.get_running_loop())
+
         if scope['type'] == 'http':
             await self.handle_http(scope=scope, receive=receive, send=send)
         elif scope['type'] == 'websocket':

--- a/tests/test_background_task_event_loop_isolation.py
+++ b/tests/test_background_task_event_loop_isolation.py
@@ -1,51 +1,9 @@
 import asyncio
+from unittest import TestCase
 from threading import Event, Thread
 
 import panther.background_tasks as background_tasks
 from panther.background_tasks import BackgroundTask
-
-
-def test_async_background_task_avoids_event_loop_mismatch():
-    previous_loop = getattr(background_tasks, '_application_event_loop', None)
-    app_loop = asyncio.new_event_loop()
-    app_loop_ready = Event()
-    app_loop_closed = Event()
-
-    def run_application_loop():
-        asyncio.set_event_loop(app_loop)
-        app_loop_ready.set()
-        app_loop.run_forever()
-        app_loop.close()
-        app_loop_closed.set()
-
-    loop_thread = Thread(target=run_application_loop, daemon=True)
-    loop_thread.start()
-    assert app_loop_ready.wait(timeout=1), 'Application event loop did not start in time.'
-
-    try:
-        _set_application_loop(app_loop)
-        loop_bound_future = asyncio.run_coroutine_threadsafe(_create_loop_bound_future(app_loop), app_loop).result(
-            timeout=1,
-        )
-        results = []
-
-        async def consume_loop_bound_future(_results):
-            await loop_bound_future
-            _results.append('completed')
-
-        app_loop.call_soon_threadsafe(app_loop.call_later, 0.01, loop_bound_future.set_result, 'ok')
-        BackgroundTask(consume_loop_bound_future, results)()
-
-        assert results == ['completed']
-    finally:
-        _set_application_loop(previous_loop)
-        app_loop.call_soon_threadsafe(app_loop.stop)
-        loop_thread.join(timeout=1)
-        assert app_loop_closed.wait(timeout=1), 'Application event loop did not stop in time.'
-
-
-async def _create_loop_bound_future(loop: asyncio.AbstractEventLoop) -> asyncio.Future:
-    return loop.create_future()
 
 
 def _set_application_loop(loop: asyncio.AbstractEventLoop | None) -> None:
@@ -53,3 +11,47 @@ def _set_application_loop(loop: asyncio.AbstractEventLoop | None) -> None:
         background_tasks.register_application_event_loop(loop)
     else:
         setattr(background_tasks, '_application_event_loop', loop)
+
+
+async def _create_loop_bound_future(loop: asyncio.AbstractEventLoop) -> asyncio.Future:
+    return loop.create_future()
+
+
+class TestBackgroundTaskEventLoopIsolation(TestCase):
+    def test_async_background_task_avoids_event_loop_mismatch(self):
+        previous_loop = getattr(background_tasks, '_application_event_loop', None)
+        app_loop = asyncio.new_event_loop()
+        app_loop_ready = Event()
+        app_loop_closed = Event()
+
+        def run_application_loop():
+            asyncio.set_event_loop(app_loop)
+            app_loop_ready.set()
+            app_loop.run_forever()
+            app_loop.close()
+            app_loop_closed.set()
+
+        loop_thread = Thread(target=run_application_loop, daemon=True)
+        loop_thread.start()
+        assert app_loop_ready.wait(timeout=1), 'Application event loop did not start in time.'
+
+        try:
+            _set_application_loop(app_loop)
+            loop_bound_future = asyncio.run_coroutine_threadsafe(
+                _create_loop_bound_future(app_loop), app_loop
+            ).result(timeout=1)
+            results = []
+
+            async def consume_loop_bound_future(_results):
+                await loop_bound_future
+                _results.append('completed')
+
+            app_loop.call_soon_threadsafe(app_loop.call_later, 0.01, loop_bound_future.set_result, 'ok')
+            BackgroundTask(consume_loop_bound_future, results)()
+
+            assert results == ['completed']
+        finally:
+            _set_application_loop(previous_loop)
+            app_loop.call_soon_threadsafe(app_loop.stop)
+            loop_thread.join(timeout=1)
+            assert app_loop_closed.wait(timeout=1), 'Application event loop did not stop in time.'

--- a/tests/test_background_task_event_loop_isolation.py
+++ b/tests/test_background_task_event_loop_isolation.py
@@ -1,0 +1,55 @@
+import asyncio
+from threading import Event, Thread
+
+import panther.background_tasks as background_tasks
+from panther.background_tasks import BackgroundTask
+
+
+def test_async_background_task_avoids_event_loop_mismatch():
+    previous_loop = getattr(background_tasks, '_application_event_loop', None)
+    app_loop = asyncio.new_event_loop()
+    app_loop_ready = Event()
+    app_loop_closed = Event()
+
+    def run_application_loop():
+        asyncio.set_event_loop(app_loop)
+        app_loop_ready.set()
+        app_loop.run_forever()
+        app_loop.close()
+        app_loop_closed.set()
+
+    loop_thread = Thread(target=run_application_loop, daemon=True)
+    loop_thread.start()
+    assert app_loop_ready.wait(timeout=1), 'Application event loop did not start in time.'
+
+    try:
+        _set_application_loop(app_loop)
+        loop_bound_future = asyncio.run_coroutine_threadsafe(_create_loop_bound_future(app_loop), app_loop).result(
+            timeout=1,
+        )
+        results = []
+
+        async def consume_loop_bound_future(_results):
+            await loop_bound_future
+            _results.append('completed')
+
+        app_loop.call_soon_threadsafe(app_loop.call_later, 0.01, loop_bound_future.set_result, 'ok')
+        BackgroundTask(consume_loop_bound_future, results)()
+
+        assert results == ['completed']
+    finally:
+        _set_application_loop(previous_loop)
+        app_loop.call_soon_threadsafe(app_loop.stop)
+        loop_thread.join(timeout=1)
+        assert app_loop_closed.wait(timeout=1), 'Application event loop did not stop in time.'
+
+
+async def _create_loop_bound_future(loop: asyncio.AbstractEventLoop) -> asyncio.Future:
+    return loop.create_future()
+
+
+def _set_application_loop(loop: asyncio.AbstractEventLoop | None) -> None:
+    if hasattr(background_tasks, 'register_application_event_loop'):
+        background_tasks.register_application_event_loop(loop)
+    else:
+        setattr(background_tasks, '_application_event_loop', loop)


### PR DESCRIPTION
This PR fixes an async event loop mismatch in background task execution.

Problem:
When a background task function is async, BackgroundTask.__call__() uses asyncio.run(...). That creates a new isolated event loop. If the task awaits async objects that belong to the live application loop, it fails (with a loop mismatch error) and task does not complete.

What I changed:
- Added runtime event loop registration in app entry:
  - Panther.__call__() now registers the currently running loop
- Updated async background task execution:
  - If an application loop is registered and alive, run coroutine with asyncio.run_coroutine_threadsafe(...).result()
  - Otherwise keep fallback to asyncio.run(...)
- Added a dedicated regression test file:
  - tests/test_background_task_event_loop_isolation.py

Test Coverage:
The new test reproduces a real loop-bound await scenario using a Future created on the application loop
- Before fix: test fails and background task logs loop mismatch
- After fix: test passes and task completes correctly

Validation:
- pytest -q tests/test_background_task_event_loop_isolation.py -q
- pytest -q tests/test_background_tasks.py tests/test_request.py -q
Both passed after the fix

Impact:
Async background tasks can now safely interact with loop-bound async runtime objects from the live app loop, which prevents silent failures in production background workflows.