### PR TITLE
fix: make find_one_or_insert race-safe on duplicate key conflicts

### DIFF
--- a/docs/docs/query.md
+++ b/docs/docs/query.md
@@ -178,8 +178,10 @@ deleted_count: int = await User.delete_many(age=18)
 Get or insert a document.
 
 ```python
-is_inserted, user = await User.find_one_or_insert(age=18, name='Ali')
+user, is_inserted = await User.find_one_or_insert(age=18, name='Ali')
 ```
+
+For correctness under concurrency, define a unique index/constraint on the queried fields.
 
 ---
 

--- a/panther/db/queries/queries.py
+++ b/panther/db/queries/queries.py
@@ -18,6 +18,19 @@ else:
 
     Self = TypeVar('Self', bound='Query')
 
+try:
+    from pymongo.errors import DuplicateKeyError as _PyMongoDuplicateKeyError
+except ImportError:
+    _PyMongoDuplicateKeyError = None
+
+
+def _is_duplicate_key_error(error: Exception) -> bool:
+    if _PyMongoDuplicateKeyError and isinstance(error, _PyMongoDuplicateKeyError):
+        return True
+    if error.__class__.__name__ == 'DuplicateKeyError':
+        return True
+    return getattr(error, 'code', None) in {11000, 11001, 12582}
+
 
 class Query(BaseQuery):
     def __init_subclass__(cls, **kwargs):
@@ -369,6 +382,7 @@ class Query(BaseQuery):
         Get a single document from the database.
         or
         Insert a single document.
+        This method requires a unique index/constraint on queried fields to be correct under concurrency.
 
         Example:
         -------
@@ -383,7 +397,14 @@ class Query(BaseQuery):
         """
         if obj := await cls.find_one(_filter, **kwargs):
             return obj, False
-        return await cls.insert_one(_filter, **kwargs), True
+        try:
+            return await cls.insert_one(_filter, **kwargs), True
+        except Exception as e:
+            if not _is_duplicate_key_error(e):
+                raise
+            if obj := await cls.find_one(_filter, **kwargs):
+                return obj, False
+            raise
 
     @classmethod
     async def find_one_or_raise(cls, _filter: dict | None = None, /, **kwargs) -> Self:

--- a/tests/test_find_one_or_insert_race.py
+++ b/tests/test_find_one_or_insert_race.py
@@ -1,0 +1,78 @@
+import asyncio
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import patch
+
+import pytest
+
+from panther import Panther
+from panther.configs import config
+from panther.db import Model
+from panther.db.connections import db
+
+
+class RaceBook(Model):
+    name: str
+
+
+@pytest.mark.mongodb
+class TestFindOneOrInsertRaceMongoDB(IsolatedAsyncioTestCase):
+    DB_NAME = 'test_find_one_or_insert_race'
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        global DATABASE
+        DATABASE = {
+            'engine': {
+                'class': 'panther.db.connections.MongoDBConnection',
+                'host': f'mongodb://127.0.0.1:27017/{cls.DB_NAME}',
+            },
+        }
+
+    def setUp(self):
+        Panther(__name__, configs=__name__, urls={})
+
+    def tearDown(self) -> None:
+        db.session.drop_collection('RaceBook')
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        config.refresh()
+
+    async def test_find_one_or_insert_with_unique_index_returns_single_record_under_concurrency(self):
+        await db.session['RaceBook'].create_index('name', unique=True)
+
+        concurrent_calls = 8
+        target_name = 'one-book-only'
+        initial_find_calls = 0
+        release_initial_finds = asyncio.Event()
+        find_lock = asyncio.Lock()
+        original_find_one = RaceBook.find_one
+
+        async def controlled_find_one(cls, _filter=None, /, **kwargs):
+            nonlocal initial_find_calls
+
+            should_force_initial_none = False
+            async with find_lock:
+                if initial_find_calls < concurrent_calls:
+                    initial_find_calls += 1
+                    should_force_initial_none = True
+                    if initial_find_calls == concurrent_calls:
+                        release_initial_finds.set()
+
+            if should_force_initial_none:
+                await release_initial_finds.wait()
+                return None
+
+            return await original_find_one(_filter, **kwargs)
+
+        with patch.object(RaceBook, 'find_one', new=classmethod(controlled_find_one)):
+            results = await asyncio.gather(
+                *[RaceBook.find_one_or_insert(name=target_name) for _ in range(concurrent_calls)],
+            )
+
+        inserted_count = sum(1 for _, is_inserted in results if is_inserted)
+        returned_ids = {obj.id for obj, _ in results}
+
+        assert inserted_count == 1
+        assert len(returned_ids) == 1
+        assert await RaceBook.count(name=target_name) == 1


### PR DESCRIPTION
Summary:
find_one_or_insert had a race condition under concurrent requests.  
The previous flow was check-then-insert, so multiple callers could pass find_one at the same time and then collide on insert.

In this PR I made find_one_or_insert race-safe by handling duplicate-key conflicts and re-fetching the existing record.

Changes:
- updated find_one_or_insert in panther/db/queries/queries.py
- current flow is:
  - try find_one
  - try insert_one
  - if duplicate-key conflict happens, run find_one again and return existing object
- added duplicate-key detection helper for robust error handling
- updated method docstring to explicitly state unique index/constraint requirement for correctness under concurrency

Tests:
added tests/test_find_one_or_insert_race.py with a real MongoDB concurrency scenario.

test_find_one_or_insert_with_unique_index_returns_single_record_under_concurrency:
- creates a unique index on name
- runs concurrent find_one_or_insert calls for the same name
- verifies:
  - only one call reports inserted=True
  - all calls return the same record id
  - only one document exists in database

Docs:
Updated docs/docs/query.md:
- fixed return-order example to user, is_inserted
- added note about unique index/constraint requirement for concurrency correctness

Validation:
- Added red/green verification for the new concurrency test:
  - before fix: test fails with DuplicateKeyError under concurrent insert race
  - after fix: test passes and all callers resolve to the same record

Backward compatibility:
- API signature and return shape are unchanged: find_one_or_insert still returns (object, is_inserted).
- Existing non-concurrent behavior remains the same.
- Under concurrent duplicate-key races, behavior is improved from raising collision errors to returning the existing record.