### PR TITLE
Add opt-in PostgreSQL support.

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -9,6 +9,22 @@ jobs:
   tests-linux:
     name: Test Linux
     runs-on: ubuntu-latest
+    services:
+      postgresql:
+        image: postgres:16
+        env:
+          POSTGRES_DB: panther_test
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d panther_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      PANTHER_POSTGRES_TEST_URL: postgresql+asyncpg://postgres:postgres@127.0.0.1:5432/panther_test
 
     steps:
       - name: Checkout source

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -9,6 +9,7 @@ jobs:
   tests-linux:
     name: Test Linux
     runs-on: ubuntu-latest
+
     services:
       postgresql:
         image: postgres:16
@@ -74,7 +75,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: Run Tests
-        run: python tests --not_mongodb --not_slow
+        run: python tests --not_mongodb --not_slow --not_postgresql
 
   tests-macos:
     name: Test MacOS
@@ -96,4 +97,4 @@ jobs:
           pip install -r requirements.txt
 
       - name: Run Tests
-        run: python tests --not_mongodb --not_slow
+        run: python tests --not_mongodb --not_slow --not_postgresql

--- a/docs/docs/admin_panel.md
+++ b/docs/docs/admin_panel.md
@@ -6,6 +6,9 @@
 
 Panther provides a built-in admin panel that allows you to easily manage your database models through a web interface.
 
+!!! warning "Document models only"
+    The built-in admin panel currently supports Panther document models backed by MongoDB or PantherDB. It does not manage PostgreSQL SQLAlchemy models. PostgreSQL applications should provide their own administration endpoints or use a SQLAlchemy-compatible admin tool.
+
 ## Enabling the Admin Panel
 
 To enable the admin panel in your project, follow these steps:
@@ -59,4 +62,4 @@ panther createuser main.py
 
 Replace `main.py` with the path to your main application file if it is different. This command will create a new user based on your `USER_MODEL` (by default, `panther.db.models.BaseUser`).
 
-Once the user is created, you can log in to the admin panel using the credentials you set during user creation. 
+Once the user is created, you can log in to the admin panel using the credentials you set during user creation.

--- a/docs/docs/authentications.md
+++ b/docs/docs/authentications.md
@@ -35,6 +35,40 @@ Panther provides three built-in authentication classes, all based on JWT (JSON W
 AUTHENTICATION = 'panther.authentications.JWTAuthentication'
 ```
 
+#### PostgreSQL user lookup
+
+The default `get_user()` implementation uses the document `USER_MODEL.find_one()` API. Applications with PostgreSQL can keep Panther's JWT parsing and token handling by overriding that existing method:
+
+```python
+from panther.authentications import JWTAuthentication
+from panther.db.connections import db
+
+from app.models import User
+
+
+class PostgreSQLJWTAuthentication(JWTAuthentication):
+    @classmethod
+    async def get_user(cls, payload: dict) -> User:
+        user_id = payload.get('user_id')
+        if user_id is None:
+            raise cls.exception('Payload does not have `user_id`')
+
+        async with db.session_context() as session:
+            user = await session.get(User, user_id)
+
+        if user is None:
+            raise cls.exception('User not found')
+        return user
+```
+
+Configure the subclass instead of the default authentication class:
+
+```python
+AUTHENTICATION = 'app.authentications.PostgreSQLJWTAuthentication'
+```
+
+The returned user must expose an `id`. For built-in token refresh and logout flows, it must also allow Panther to store transient `_auth_token` and `_auth_refresh_token` attributes.
+
 #### JWT Configuration
 You can customize JWT behavior by setting `JWT_CONFIG` in your configs. Example:
 
@@ -113,7 +147,7 @@ You can implement your own authentication logic by either:
    class CustomAuthentication(BaseAuthentication):
        async def __call__(self, request: Request):
            # Your authentication logic here
-           # Return an instance of USER_MODEL (default: BaseUser)
+           # Return the authenticated application user.
            # Or raise AuthenticationAPIError on failure
            ...
    ```
@@ -121,7 +155,7 @@ You can implement your own authentication logic by either:
    ```python
    async def custom_authentication(request: Request):
        # Your authentication logic here
-       # Return an instance of USER_MODEL (default: BaseUser)
+           # Return the authenticated application user.
        # Or raise AuthenticationAPIError on failure
        ...
    ```

--- a/docs/docs/database.md
+++ b/docs/docs/database.md
@@ -1,6 +1,6 @@
 # Database Support in Panther
 
-Panther natively supports two document databases: `MongoDB` and `PantherDB`. However, you can also define your own custom database connections and queries.
+Panther natively supports `MongoDB`, `PantherDB`, and `PostgreSQL`. You can also define custom database connections and queries.
 
 The built-in `panther.db.Model` is a document model. It remains available for compatibility; `panther.db.DocumentModel` is its explicit name. Relational integrations should provide their own persistence models rather than inheriting from either class.
 
@@ -25,6 +25,7 @@ DATABASE = {
 - **Built-in supported engines:**
   - `panther.db.connections.PantherDBConnection`
   - `panther.db.connections.MongoDBConnection`
+  - `panther.db.connections.PostgreSQLConnection`
 - All values in `engine` (except `class`) are passed to the `__init__` method of the specified class.
 - The `query` key is optional for the default supported engines, but you can customize it if needed.
 
@@ -34,7 +35,7 @@ Custom engines should subclass `panther.db.connections.BaseDatabaseConnection` a
 
 Query implementations must subclass `panther.db.queries.base_queries.BaseQuery`.
 
-Backends declare capabilities rather than requiring Panther to check their concrete class. The built-in document backends use `uses_document_models`; MongoDB additionally uses `uses_object_ids` and `uses_mongo_query_syntax`. A future relational backend can leave these capabilities disabled and provide its own query implementation.
+Backends declare capabilities rather than requiring Panther to check their concrete class. The built-in document backends use `uses_document_models`; MongoDB additionally uses `uses_object_ids` and `uses_mongo_query_syntax`. Relational backends leave these capabilities disabled and do not use the document query API.
 
 If a backend needs an active event loop to allocate or release resources, implement its async `startup()` and `shutdown()` hooks. Panther invokes them during ASGI lifespan startup and shutdown.
 
@@ -44,12 +45,6 @@ Backends can also override `session_context()` to provide a scoped unit of work.
 from contextlib import asynccontextmanager
 
 from panther.db.connections import BaseDatabaseConnection, db
-from panther.db.queries.base_queries import BaseQuery
-
-
-class SQLQuery(BaseQuery):
-    # Implement the backend-neutral query operations here.
-    pass
 
 
 class SQLConnection(BaseDatabaseConnection):
@@ -60,19 +55,10 @@ class SQLConnection(BaseDatabaseConnection):
     def session(self):
         return self._session_factory
 
-    @classmethod
-    def get_query_engine(cls):
-        return SQLQuery
-
     @asynccontextmanager
     async def session_context(self):
         async with self._session_factory() as session:
-            try:
-                yield session
-                await session.commit()
-            except Exception:
-                await session.rollback()
-                raise
+            yield session
 
 
 async with db.session_context() as session:
@@ -118,6 +104,70 @@ DATABASE = {
 
 ### Notes
 - The parameters for the engine are the same as those for `pymongo.MongoClient`. See the [PyMongo documentation](https://pymongo.readthedocs.io/en/stable/tutorial.html#making-a-connection-with-mongoclient) for details.
+
+---
+
+## PostgreSQL
+
+Install the optional PostgreSQL dependencies:
+
+```bash
+pip install 'panther[postgresql]'
+```
+
+Configure Panther with a SQLAlchemy async URL:
+
+```python
+DATABASE = {
+    'engine': {
+        'class': 'panther.db.connections.PostgreSQLConnection',
+        'url': 'postgresql+asyncpg://postgres:password@127.0.0.1:5432/my_database',
+        'echo': False,  # Optional SQLAlchemy engine setting
+    },
+}
+```
+
+`PostgreSQLConnection` validates the engine configuration while Panther loads settings. During ASGI startup, Panther opens a connection and runs a health check; invalid credentials, hosts, or database names prevent the application from serving requests.
+
+### Define SQLAlchemy models
+
+PostgreSQL applications use ordinary SQLAlchemy declarative models. Do not inherit from `panther.db.DocumentModel` or use document query methods such as `find()`.
+
+```python
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class User(Base):
+    __tablename__ = 'users'
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str]
+```
+
+### Use sessions explicitly
+
+`db.session` is the SQLAlchemy session factory. Prefer `db.session_context()` so every unit of work receives a new session and failures are rolled back automatically. Successful writes require an explicit commit.
+
+```python
+from sqlalchemy import select
+
+from panther.db.connections import db
+
+
+async def create_and_list_users(name: str) -> list[User]:
+    async with db.session_context() as session:
+        session.add(User(name=name))
+        await session.commit()
+
+        result = await session.execute(select(User).order_by(User.id))
+        return list(result.scalars())
+```
+
+Panther disposes the connection pool during ASGI shutdown.
 
 ---
 

--- a/docs/docs/database.md
+++ b/docs/docs/database.md
@@ -169,6 +169,22 @@ async def create_and_list_users(name: str) -> list[User]:
 
 Panther disposes the connection pool during ASGI shutdown.
 
+Use `sqlalchemy.text()` for raw SQL and bind external values as parameters rather than formatting them into the query string:
+
+```python
+from sqlalchemy import text
+
+
+async with db.session_context() as session:
+    result = await session.execute(
+        text('SELECT id, name FROM users WHERE id = :user_id'),
+        {'user_id': user_id},
+    )
+    user = result.mappings().one_or_none()
+```
+
+For a complete CRUD, relationship, and cursor-pagination example, see the `examples/postgresql` directory in the Panther repository.
+
 ---
 
 ## How Does It Work?

--- a/docs/docs/first_crud.md
+++ b/docs/docs/first_crud.md
@@ -2,6 +2,9 @@ We assume you have successfully set up your project following the [Introduction]
 
 In this guide, we will create a `CRUD` (`Create`, `Retrieve`, `Update`, and `Delete`) API for managing `Book` entities.
 
+!!! note "Document CRUD APIs"
+    This guide uses Panther document `Model` classes and the built-in document generic APIs. PostgreSQL applications use SQLAlchemy models and custom Panther endpoints instead; see the [PostgreSQL guide](database.md#postgresql) and the `examples/postgresql` application in the Panther repository.
+
 ---
 
 ## Project Structure

--- a/docs/docs/model.md
+++ b/docs/docs/model.md
@@ -2,6 +2,9 @@
 
 Panther models allow you to define your data schema and interact with the database using Python classes. They are built on top of `pydantic.BaseModel` and extend its functionality with database query capabilities.
 
+!!! note "Document models only"
+    `panther.db.Model` and `panther.db.DocumentModel` are Panther's document-model APIs for MongoDB and PantherDB. PostgreSQL applications should define standard SQLAlchemy declarative models and use SQLAlchemy sessions and queries; see the [PostgreSQL guide](database.md#postgresql).
+
 ## Creating a Model
 
 To create a Panther model, define a class that inherits from `panther.db.Model`:
@@ -165,5 +168,4 @@ print(document.file.size)  # File size in bytes
 with document.file as f:
     content = f.read()
 ```
-
 

--- a/docs/docs/postgresql_migrations.md
+++ b/docs/docs/postgresql_migrations.md
@@ -1,0 +1,76 @@
+# PostgreSQL Migrations
+
+Panther uses [Alembic](https://alembic.sqlalchemy.org/) for PostgreSQL schema migrations. Alembic owns schema history; Panther does not generate or apply migrations during application startup.
+
+Install PostgreSQL support, including Alembic:
+
+```bash
+pip install 'panther[postgresql]'
+```
+
+## Initialize Alembic
+
+Run this once from the project root:
+
+```bash
+alembic init -t async migrations
+```
+
+Set the async SQLAlchemy URL in `alembic.ini`:
+
+```ini
+sqlalchemy.url = postgresql+asyncpg://postgres:password@127.0.0.1:5432/my_database
+```
+
+The URL should match the one configured for `PostgreSQLConnection` in Panther.
+
+## Register model metadata
+
+Alembic needs the metadata from your SQLAlchemy declarative base to generate migrations. In `migrations/env.py`, import the base after the generated imports and assign its metadata:
+
+```python
+from app.models import Base
+
+target_metadata = Base.metadata
+```
+
+For example, application models can share this base:
+
+```python
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class User(Base):
+    __tablename__ = 'users'
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str]
+```
+
+Import every module that declares models before Alembic reads `Base.metadata`; otherwise, autogeneration cannot see those tables.
+
+## Create and apply migrations
+
+Generate a revision after changing SQLAlchemy models:
+
+```bash
+alembic revision --autogenerate -m 'create users'
+```
+
+Review the generated migration, then apply it:
+
+```bash
+alembic upgrade head
+```
+
+To revert the latest revision during development:
+
+```bash
+alembic downgrade -1
+```
+
+Run `alembic upgrade head` as a deployment step before starting Panther. Do not rely on application startup to modify production schemas.

--- a/docs/docs/query.md
+++ b/docs/docs/query.md
@@ -2,6 +2,9 @@
 
 Panther ODM provides a simple, async interface for interacting with your database models. This guide covers the most common operations.
 
+!!! note "Document queries only"
+    These query methods apply to Panther document models used with MongoDB and PantherDB. PostgreSQL applications use SQLAlchemy queries such as `select()` within `db.session_context()`; see the [PostgreSQL guide](database.md#postgresql).
+
 ---
 
 ### find_one

--- a/docs/docs/release_notes.md
+++ b/docs/docs/release_notes.md
@@ -1,5 +1,12 @@
 # Panther Release Notes
 
+### 5.4.0
+
+- Add opt-in PostgreSQL support using SQLAlchemy async and `asyncpg` through `PostgreSQLConnection`.
+- Add PostgreSQL connection lifecycle checks, scoped SQLAlchemy sessions, explicit transaction control, and integration-test coverage.
+- Document PostgreSQL configuration, SQLAlchemy API patterns, raw SQL execution, Alembic migrations, and SQL-backed JWT user lookup.
+- Clarify that Panther document models, document generic APIs, document query methods, and the built-in admin panel do not support SQLAlchemy models.
+
 ### 5.3.0
 
 - Add a backend-neutral database connection foundation with lifecycle hooks and scoped-session support.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -39,6 +39,7 @@ nav:
   - Models: 'model.md'
   - File Handling: 'file_handling.md'
   - Database: 'database.md'
+  - PostgreSQL Migrations: 'postgresql_migrations.md'
   - Query: 'query.md'
   - Redis: 'redis.md'
   - Events: 'events.md'

--- a/examples/postgresql/README.md
+++ b/examples/postgresql/README.md
@@ -1,0 +1,32 @@
+# PostgreSQL API Example
+
+This example uses Panther with normal SQLAlchemy models, PostgreSQL, and explicit session commits. It does not use `DocumentModel`, document query methods, generic document CRUD APIs, or the Panther admin panel.
+
+## Run locally
+
+Start PostgreSQL:
+
+```bash
+docker run --rm -p 5432:5432 -d --name postgres \
+  -e POSTGRES_DB=panther_example -e POSTGRES_USER=postgres \
+  -e POSTGRES_PASSWORD=postgres postgres:16
+```
+
+Install Panther with PostgreSQL support and start the application:
+
+```bash
+pip install 'panther[postgresql]'
+panther run main:app --reload
+```
+
+Set `DATABASE_URL` when your database does not use the default local connection string.
+
+Create the `authors` and `books` tables with Alembic before starting the application. See the [PostgreSQL migrations guide](../../docs/docs/postgresql_migrations.md).
+
+## API patterns
+
+- `POST /authors/create/` creates an author and explicitly commits.
+- `GET /authors/?limit=20&cursor=10` uses cursor pagination and `selectinload` to fetch authors with books efficiently.
+- `GET /authors/raw/?limit=20` executes a parameterized raw SQL query with `sqlalchemy.text()`.
+- `GET`, `PUT`, and `DELETE /authors/<author_id>/` show read, update, and delete operations.
+- `POST /authors/<author_id>/books/create/` creates a related record in an explicit transaction.

--- a/examples/postgresql/main.py
+++ b/examples/postgresql/main.py
@@ -1,0 +1,182 @@
+import os
+
+from pydantic import BaseModel, Field
+from sqlalchemy import ForeignKey, select, text
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship, selectinload
+
+from panther import Panther, status
+from panther.app import API
+from panther.db.connections import db
+from panther.request import Request
+from panther.response import Response
+
+DATABASE = {
+    'engine': {
+        'class': 'panther.db.connections.PostgreSQLConnection',
+        'url': os.getenv(
+            'DATABASE_URL',
+            'postgresql+asyncpg://postgres:postgres@127.0.0.1:5432/panther_example',
+        ),
+    },
+}
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class Author(Base):
+    __tablename__ = 'authors'
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str]
+    books: Mapped[list['Book']] = relationship(back_populates='author', cascade='all, delete-orphan')
+
+
+class Book(Base):
+    __tablename__ = 'books'
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    title: Mapped[str]
+    author_id: Mapped[int] = mapped_column(ForeignKey('authors.id'))
+    author: Mapped[Author] = relationship(back_populates='books')
+
+
+class AuthorInput(BaseModel):
+    name: str = Field(min_length=1)
+
+
+class AuthorUpdate(BaseModel):
+    name: str = Field(min_length=1)
+
+
+class BookInput(BaseModel):
+    title: str = Field(min_length=1)
+
+
+class BookOutput(BaseModel):
+    id: int
+    title: str
+
+
+class AuthorOutput(BaseModel):
+    id: int
+    name: str
+    books: list[BookOutput]
+
+
+class AuthorPageOutput(BaseModel):
+    items: list[AuthorOutput]
+    next_cursor: int | None
+
+
+class AuthorSummaryOutput(BaseModel):
+    id: int
+    name: str
+
+
+def serialize_author(author: Author) -> dict:
+    return AuthorOutput(
+        id=author.id,
+        name=author.name,
+        books=[BookOutput(id=book.id, title=book.title) for book in author.books],
+    ).model_dump()
+
+
+@API(methods=['GET'])
+async def list_author_summaries_with_raw_sql(request: Request):
+    limit = min(max(int(request.query_params.get('limit', 20)), 1), 100)
+    statement = text('SELECT id, name FROM authors ORDER BY id LIMIT :limit')
+
+    async with db.session_context() as session:
+        rows = await session.execute(statement, {'limit': limit})
+        authors = [AuthorSummaryOutput(**row).model_dump() for row in rows.mappings()]
+
+    return authors
+
+
+@API(methods=['POST'], input_model=AuthorInput)
+async def create_author(request: Request):
+    async with db.session_context() as session:
+        author = Author(**request.validated_data.model_dump())
+        session.add(author)
+        await session.commit()
+        return Response(data={'id': author.id, 'name': author.name}, status_code=status.HTTP_201_CREATED)
+
+
+@API(methods=['GET'])
+async def list_authors(request: Request):
+    limit = min(max(int(request.query_params.get('limit', 20)), 1), 100)
+    cursor = request.query_params.get('cursor')
+    statement = select(Author).options(selectinload(Author.books)).order_by(Author.id).limit(limit + 1)
+    if cursor:
+        statement = statement.where(Author.id > int(cursor))
+
+    async with db.session_context() as session:
+        authors = list((await session.execute(statement)).scalars())
+
+    has_next_page = len(authors) > limit
+    authors = authors[:limit]
+    return AuthorPageOutput(
+        items=[AuthorOutput(**serialize_author(author)) for author in authors],
+        next_cursor=authors[-1].id if has_next_page else None,
+    ).model_dump()
+
+
+@API(methods=['GET'])
+async def get_author(author_id: int):
+    statement = select(Author).options(selectinload(Author.books)).where(Author.id == author_id)
+    async with db.session_context() as session:
+        author = (await session.execute(statement)).scalar_one_or_none()
+
+    if author is None:
+        return Response(data={'detail': 'Author not found'}, status_code=status.HTTP_404_NOT_FOUND)
+    return serialize_author(author)
+
+
+@API(methods=['PUT'], input_model=AuthorUpdate)
+async def update_author(request: Request, author_id: int):
+    async with db.session_context() as session:
+        author = await session.get(Author, author_id)
+        if author is None:
+            return Response(data={'detail': 'Author not found'}, status_code=status.HTTP_404_NOT_FOUND)
+        author.name = request.validated_data.name
+        await session.commit()
+        return {'id': author.id, 'name': author.name}
+
+
+@API(methods=['DELETE'])
+async def delete_author(author_id: int):
+    async with db.session_context() as session:
+        author = await session.get(Author, author_id)
+        if author is None:
+            return Response(data={'detail': 'Author not found'}, status_code=status.HTTP_404_NOT_FOUND)
+        await session.delete(author)
+        await session.commit()
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@API(methods=['POST'], input_model=BookInput)
+async def create_book(request: Request, author_id: int):
+    async with db.session_context() as session:
+        author = await session.get(Author, author_id)
+        if author is None:
+            return Response(data={'detail': 'Author not found'}, status_code=status.HTTP_404_NOT_FOUND)
+        book = Book(author=author, **request.validated_data.model_dump())
+        session.add(book)
+        await session.commit()
+        return Response(data={'id': book.id, 'title': book.title}, status_code=status.HTTP_201_CREATED)
+
+
+url_routing = {
+    'authors/': list_authors,
+    'authors/raw/': list_author_summaries_with_raw_sql,
+    'authors/create/': create_author,
+    'authors/<author_id>/': get_author,
+    'authors/<author_id>/update/': update_author,
+    'authors/<author_id>/delete/': delete_author,
+    'authors/<author_id>/books/create/': create_book,
+}
+
+app = Panther(__name__, configs=__name__, urls=url_routing)

--- a/panther/__init__.py
+++ b/panther/__init__.py
@@ -1,6 +1,6 @@
 from panther.main import Panther  # noqa: F401
 
-__version__ = '5.3.0'
+__version__ = '5.4.0'
 
 
 def version():

--- a/panther/db/connections.py
+++ b/panther/db/connections.py
@@ -124,6 +124,48 @@ class MongoDBConnection(BaseDatabaseConnection):
         return self._client
 
 
+class PostgreSQLConnection(BaseDatabaseConnection):
+    """Async PostgreSQL backend powered by SQLAlchemy and asyncpg."""
+
+    def init(self, url: str, **kwargs: Any) -> None:
+        try:
+            from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+        except ModuleNotFoundError as e:
+            raise import_error(e, package='panther[postgresql]')
+
+        self._engine = create_async_engine(url, **kwargs)
+        self._session_factory = async_sessionmaker(self._engine, expire_on_commit=False)
+
+    @property
+    def session(self):
+        """Return the SQLAlchemy session factory."""
+        return self._session_factory
+
+    @property
+    def client(self):
+        """Return the SQLAlchemy async engine."""
+        return self._engine
+
+    @contextlib.asynccontextmanager
+    async def session_context(self):
+        """Yield a new session and roll it back if the unit of work fails."""
+        async with self._session_factory() as session:
+            try:
+                yield session
+            except BaseException:
+                await session.rollback()
+                raise
+
+    async def startup(self) -> None:
+        from sqlalchemy import text
+
+        async with self._engine.connect() as connection:
+            await connection.execute(text('SELECT 1'))
+
+    async def shutdown(self) -> None:
+        await self._engine.dispose()
+
+
 class PantherDBConnection(BaseDatabaseConnection):
     uses_document_models = True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,5 +8,6 @@ build-backend = "setuptools.build_meta"
 [tool.pytest.ini_options]
 markers = [
 	"mongodb: marks mongodb tests",
+	"postgresql: marks PostgreSQL integration tests",
 	"slow: marks slow tests"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,9 @@ pytest
 cryptography~=42.0
 websockets
 motor
+SQLAlchemy>=2.0,<3.0
+asyncpg>=0.29,<1.0
+greenlet>=3.0,<4.0
 mkdocs
 mkdocs-material
 ruff

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ motor
 SQLAlchemy>=2.0,<3.0
 asyncpg>=0.29,<1.0
 greenlet>=3.0,<4.0
+alembic>=1.13,<2.0
 mkdocs
 mkdocs-material
 ruff

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ EXTRAS_REQUIRE = {
         'SQLAlchemy>=2.0,<3.0',
         'asyncpg>=0.29,<1.0',
         'greenlet>=3.0,<4.0',
+        'alembic>=1.13,<2.0',
     ],
     'full': [
         'redis==6.2.0',

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,10 @@ INSTALL_REQUIRES = [
 ]
 
 EXTRAS_REQUIRE = {
+    'postgresql': [
+        'SQLAlchemy>=2.0,<3.0',
+        'asyncpg>=0.29,<1.0',
+    ],
     'full': [
         'redis==6.2.0',
         'motor~=3.7.1',

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ EXTRAS_REQUIRE = {
     'postgresql': [
         'SQLAlchemy>=2.0,<3.0',
         'asyncpg>=0.29,<1.0',
+        'greenlet>=3.0,<4.0',
     ],
     'full': [
         'redis==6.2.0',

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -28,6 +28,8 @@ def main():
     # Make sure to define each flag in here, pyproject.toml and on top of the test target.
     parser.add_argument('--mongodb', action='store_true', help='Only run mongodb tests.')
     parser.add_argument('--not_mongodb', action='store_true', help='Does not run mongodb tests.')
+    parser.add_argument('--postgresql', action='store_true', help='Only run PostgreSQL tests.')
+    parser.add_argument('--not_postgresql', action='store_true', help='Does not run PostgreSQL tests.')
     parser.add_argument('--slow', action='store_true', help='Only run slow tests.')
     parser.add_argument('--not_slow', action='store_true', help='Does not run slow tests.')
     args = parser.parse_args()
@@ -41,6 +43,10 @@ def main():
         flags.append('not slow')
     if args.mongodb:
         flags.append('mongodb')
+    if args.not_postgresql:
+        flags.append('not postgresql')
+    if args.postgresql:
+        flags.append('postgresql')
     if args.slow:
         flags.append('slow')
     if flags:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,7 +10,7 @@ from panther.authentications import CookieJWTAuthentication, QueryParamJWTAuthen
 from panther.base_websocket import WebsocketConnections
 from panther.configs import JWTConfig, config
 from panther.db import Model
-from panther.db.connections import MongoDBConnection, PantherDBConnection
+from panther.db.connections import MongoDBConnection, PantherDBConnection, PostgreSQLConnection
 from panther.db.queries.mongodb_queries import BaseMongoDBQuery
 from panther.db.queries.pantherdb_queries import BasePantherDBQuery
 from panther.events import Event
@@ -71,6 +71,9 @@ class TestConfig(TestCase):
         assert MongoDBConnection.uses_object_ids is True
         assert MongoDBConnection.uses_mongo_query_syntax is True
         assert MongoDBConnection.get_query_engine() is BaseMongoDBQuery
+
+        assert PostgreSQLConnection.uses_document_models is False
+        assert PostgreSQLConnection.get_query_engine() is None
 
     def test_loading_known_configs(self):
         global \

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -1,0 +1,92 @@
+"""PostgreSQL integration tests.
+
+Start the local test database with:
+
+    docker run --rm -p 5432:5432 -d --name postgres \
+      -e POSTGRES_DB=panther_test -e POSTGRES_USER=postgres \
+      -e POSTGRES_PASSWORD=postgres postgres:16
+"""
+
+import asyncio
+import os
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock
+
+import pytest
+
+POSTGRES_TEST_URL = os.getenv(
+    'PANTHER_POSTGRES_TEST_URL',
+    'postgresql+asyncpg://postgres:postgres@127.0.0.1:5432/panther_test',
+)
+
+from sqlalchemy import text
+
+from panther.db.connections import PostgreSQLConnection
+
+pytestmark = pytest.mark.postgresql
+
+
+class TestPostgreSQLConnection(IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.connection = None
+        self.connection = PostgreSQLConnection(url=POSTGRES_TEST_URL)
+        await self.connection.startup()
+        async with self.connection.session_context() as session:
+            await session.execute(
+                text(
+                    'CREATE TABLE IF NOT EXISTS panther_postgresql_test_records '
+                    '(id INTEGER PRIMARY KEY, value TEXT NOT NULL)',
+                ),
+            )
+            await session.execute(text('TRUNCATE panther_postgresql_test_records'))
+            await session.commit()
+
+    async def asyncTearDown(self):
+        if self.connection is not None:
+            await self.connection.shutdown()
+
+    async def test_startup_and_session_execution(self):
+        async with self.connection.session_context() as session:
+            result = await session.execute(text('SELECT 1'))
+
+        assert result.scalar_one() == 1
+
+    async def test_session_context_requires_explicit_commit(self):
+        async with self.connection.session_context() as session:
+            await session.execute(text("INSERT INTO panther_postgresql_test_records VALUES (1, 'saved')"))
+            await session.commit()
+
+        async with self.connection.session_context() as session:
+            result = await session.execute(text('SELECT value FROM panther_postgresql_test_records WHERE id = 1'))
+
+        assert result.scalar_one() == 'saved'
+
+    async def test_session_context_rolls_back_on_error(self):
+        with self.assertRaisesRegex(RuntimeError, 'rollback'):
+            async with self.connection.session_context() as session:
+                await session.execute(text("INSERT INTO panther_postgresql_test_records VALUES (1, 'rolled back')"))
+                raise RuntimeError('rollback')
+
+        async with self.connection.session_context() as session:
+            result = await session.execute(text('SELECT COUNT(*) FROM panther_postgresql_test_records'))
+
+        assert result.scalar_one() == 0
+
+    async def test_startup_fails_for_an_unreachable_database(self):
+        connection = PostgreSQLConnection(
+            url='postgresql+asyncpg://postgres:postgres@127.0.0.1:1/panther_test',
+            connect_args={'timeout': 1},
+        )
+        with self.assertRaises(Exception):
+            await asyncio.wait_for(connection.startup(), timeout=2)
+        await connection.shutdown()
+
+    async def test_shutdown_disposes_the_engine(self):
+        connection = object.__new__(PostgreSQLConnection)
+        engine = type('Engine', (), {})()
+        engine.dispose = AsyncMock()
+        connection._engine = engine
+
+        await connection.shutdown()
+
+        engine.dispose.assert_awaited_once()


### PR DESCRIPTION
Add SQLAlchemy async and asyncpg PostgreSQL connectivity, lifecycle checks,
sessions, integration tests, documentation, migrations guidance, and examples.

Document-only models, generic APIs, and the admin panel remain unchanged.